### PR TITLE
Refactor config to use env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+config.ini
+php_errors.log
+error.log
+*.bak

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# PDV VANZELOTTI
+
+This project requires database credentials for operation. `config.php` reads these values from environment variables. Define the following variables before running the application or provide them in a `config.ini` file located in the project root:
+
+```
+DB_HOST     # Database host name
+DB_NAME     # Database name
+DB_USER     # Database user
+DB_PASS     # Database password
+```
+
+Example `config.ini`:
+
+```
+DB_HOST=localhost
+DB_NAME=exampledb
+DB_USER=dbuser
+DB_PASS=secret
+```
+
+Environment variables take precedence over values from `config.ini`. If neither is available the application will stop with an error.
+

--- a/config.php
+++ b/config.php
@@ -1,8 +1,25 @@
 <?php
-$host = 'localhost';
-$dbname = 'u693220259_pdv';
-$username = 'u693220259_pdvadm';
-$password = '6G&]N/vi~';
+$host = getenv('DB_HOST');
+$dbname = getenv('DB_NAME');
+$username = getenv('DB_USER');
+$password = getenv('DB_PASS');
+
+if (!$host || !$dbname || !$username || $password === false) {
+    $configFile = __DIR__ . '/config.ini';
+    if (is_readable($configFile)) {
+        $config = parse_ini_file($configFile);
+        $host = $host ?: ($config['DB_HOST'] ?? null);
+        $dbname = $dbname ?: ($config['DB_NAME'] ?? null);
+        $username = $username ?: ($config['DB_USER'] ?? null);
+        if ($password === false || $password === null) {
+            $password = $config['DB_PASS'] ?? null;
+        }
+    }
+}
+
+if (!$host || !$dbname || !$username || $password === null || $password === false) {
+    die('Database configuration not provided.');
+}
 
 try {
     $conn = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);
@@ -32,4 +49,5 @@ if (!isset($_SESSION['current_order'])) {
         'change' => 0
     ];
 }
+
 ?>


### PR DESCRIPTION
## Summary
- load database settings in `config.php` from environment variables or `config.ini`
- add `.gitignore` to ignore local files
- document required environment variables in new `README.md`

## Testing
- `php -l config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684de3cb783c8332bbe22d406b1cf54e