### PR TITLE
Use env vars for DB config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+php_errors.log
+error.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# PDV-VANZELOTTI
+
+This project requires database credentials provided via environment variables.
+
+1. Copy `env.example` to `.env`.
+2. Edit `.env` and set the values for:
+   - `DB_HOST`
+   - `DB_NAME`
+   - `DB_USER`
+   - `DB_PASS`
+3. Ensure these variables are available to PHP (e.g. by exporting them or using a tool that loads `.env` files).
+
+`config.php` will read these variables using `$_ENV`/`getenv()` when establishing the database connection.

--- a/config.php
+++ b/config.php
@@ -1,8 +1,8 @@
 <?php
-$host = 'localhost';
-$dbname = 'u693220259_pdv';
-$username = 'u693220259_pdvadm';
-$password = '6G&]N/vi~';
+$host = $_ENV['DB_HOST'] ?? getenv('DB_HOST');
+$dbname = $_ENV['DB_NAME'] ?? getenv('DB_NAME');
+$username = $_ENV['DB_USER'] ?? getenv('DB_USER');
+$password = $_ENV['DB_PASS'] ?? getenv('DB_PASS');
 
 try {
     $conn = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);

--- a/env.example
+++ b/env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_NAME=your_database
+DB_USER=your_username
+DB_PASS=your_password


### PR DESCRIPTION
## Summary
- load DB credentials from environment variables in `config.php`
- document required variables in `env.example`
- show how to create a `.env` in new README
- add `.gitignore` for local files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ddff290b08332b96810fca033f7e2