### PR TITLE
Remove session_start from functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,4 @@
 <?php
-session_start();
-
 // Habilitar depuração (remover em produção)
 ini_set('display_errors', 0);
 ini_set('display_startup_errors', 1);


### PR DESCRIPTION
## Summary
- remove the unneeded `session_start()` call from `functions.php`

## Testing
- `php -l functions.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684de0012d288332a6dac12d4ae3dc9d