### PR TITLE
Add sales table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# PDV-Vanzelotti
+
+This project is a simple POS (Point of Sale) application written in PHP. It uses a MySQL database.
+
+## Database Setup
+
+1. Create a MySQL database and user.
+2. Import the migration located at `migrations/001_create_sales_table.sql` to create the `sales` table:
+
+```bash
+mysql -u <user> -p <database> < migrations/001_create_sales_table.sql
+```
+
+3. Update `config.php` with the connection credentials for your database.
+
+After running the migration you can use the application normally.

--- a/migrations/001_create_sales_table.sql
+++ b/migrations/001_create_sales_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS sales (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    date DATETIME NOT NULL,
+    table_number INT NOT NULL,
+    items_json TEXT NOT NULL,
+    payment_method VARCHAR(50) NOT NULL,
+    subtotal DECIMAL(10,2) NOT NULL,
+    service_tax DECIMAL(10,2) NOT NULL,
+    total DECIMAL(10,2) NOT NULL,
+    customer_id INT NULL,
+    amount_received DECIMAL(10,2) DEFAULT 0,
+    change_amount DECIMAL(10,2) DEFAULT 0,
+    status VARCHAR(20) NOT NULL
+);


### PR DESCRIPTION
## Summary
- create migrations folder with SQL to create `sales`
- document DB migration steps in README

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de165dbac8332a857b030946d1920