### PR TITLE
Add installation docs and schema SQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_NAME=pdv
+DB_USER=pdvuser
+DB_PASS=secret

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# PDV Vanzelotti
+
+This project is a simple point of sale (PDV) system built with PHP.
+
+## Requirements
+
+- **PHP 7.4+** with PDO extension enabled.
+- **MySQL 5.7+** or MariaDB equivalent.
+- Web server such as Apache or the built‑in PHP development server.
+
+## Database Setup
+
+A full schema is available in `database/schema.sql`. The project also includes a migration script for the new `sales` table in `database/migrations/001_create_sales_table.sql`.
+
+To initialise the database:
+
+```bash
+mysql -u <user> -p <database> < database/schema.sql
+mysql -u <user> -p <database> < database/migrations/001_create_sales_table.sql
+```
+
+## Environment Variables
+
+Database credentials can be provided via environment variables. A sample file is available at `.env.example`.
+
+- `DB_HOST` – MySQL host (default `localhost`)
+- `DB_NAME` – database name
+- `DB_USER` – database user
+- `DB_PASS` – database password
+
+If these variables are not set, values defined in `config.php` are used.
+
+## Running the Application
+
+1. Install PHP and MySQL.
+2. Configure your database credentials as above.
+3. Start the PHP development server from the project root:
+
+```bash
+php -S localhost:8000
+```
+
+4. Open `http://localhost:8000/index.php` in your browser.
+

--- a/config.php
+++ b/config.php
@@ -1,8 +1,8 @@
 <?php
-$host = 'localhost';
-$dbname = 'u693220259_pdv';
-$username = 'u693220259_pdvadm';
-$password = '6G&]N/vi~';
+$host = getenv('DB_HOST') ?: 'localhost';
+$dbname = getenv('DB_NAME') ?: 'u693220259_pdv';
+$username = getenv('DB_USER') ?: 'u693220259_pdvadm';
+$password = getenv('DB_PASS') ?: '6G&]N/vi~';
 
 try {
     $conn = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);

--- a/database/migrations/001_create_sales_table.sql
+++ b/database/migrations/001_create_sales_table.sql
@@ -1,0 +1,17 @@
+-- Migration: create sales table
+CREATE TABLE IF NOT EXISTS `sales` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `date` DATETIME NOT NULL,
+    `table_number` INT NOT NULL,
+    `items_json` JSON NOT NULL,
+    `payment_method` VARCHAR(50) NOT NULL,
+    `subtotal` DECIMAL(10,2) NOT NULL,
+    `service_tax` DECIMAL(10,2) NOT NULL,
+    `total` DECIMAL(10,2) NOT NULL,
+    `customer_id` INT NULL,
+    `amount_received` DECIMAL(10,2) NOT NULL,
+    `change_amount` DECIMAL(10,2) NOT NULL,
+    `status` VARCHAR(20) NOT NULL,
+    FOREIGN KEY (`customer_id`) REFERENCES `customers`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,35 @@
+-- Base schema for PDV Vanzelotti
+
+CREATE TABLE IF NOT EXISTS `settings` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(255) NOT NULL,
+    `logo` VARCHAR(255) NULL,
+    `cnpj` VARCHAR(18) NULL,
+    `address` VARCHAR(255) NULL,
+    `service_tax_percent` DECIMAL(5,2) DEFAULT 0,
+    `auto_print` TINYINT(1) DEFAULT 0,
+    `tables_count` INT DEFAULT 10,
+    `payment_methods` TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `menu_items` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(255) NOT NULL,
+    `category` VARCHAR(100) NULL,
+    `price` DECIMAL(10,2) NOT NULL,
+    `image` VARCHAR(255) NULL,
+    `status` ENUM('active','inactive') DEFAULT 'active',
+    `description` TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `customers` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(255) NOT NULL,
+    `phone` VARCHAR(20) NULL,
+    `email` VARCHAR(255) NULL,
+    `cpf` VARCHAR(14) NULL,
+    `birthdate` DATE NULL,
+    `address` VARCHAR(255) NULL,
+    `status` ENUM('active','inactive') DEFAULT 'active'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+


### PR DESCRIPTION
## Summary
- document server requirements and setup instructions
- add sample environment file
- provide database schema and sales migration
- support DB config via env vars

## Testing
- `php -l config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de168fabc83328cd0867aa0d29c22